### PR TITLE
PR -- Request for inspection of routing the API correctly, frontend seems to override

### DIFF
--- a/.issues/1_deployment.md
+++ b/.issues/1_deployment.md
@@ -50,7 +50,7 @@ urlpatterns = [
 ]
 ```
 
-
+http://127.0.0.1:8000/api/ works as expected, serves the API.
 
 
 

--- a/.issues/1_deployment.md
+++ b/.issues/1_deployment.md
@@ -1,0 +1,56 @@
+Deployment issues: 
+
+Expecting the API to be hosted on `https://team5-api-eu-5d24fa110c36.herokuapp.com/api/`
+
+Expecting the frontend to be hosted on `https://team5-api-eu-5d24fa110c36.herokuapp.com/`
+
+
+--- 
+
+The Frontend is hosted on `https://team5-frontend-eu-5d24fa110c36.herokuapp.com/`
+
+But the API instead hosts the frontend on `https://team5-api-eu-5d24fa110c36.herokuapp.com/api`
+
+
+---
+
+deployment is managed by `Procfile` in the root directory
+
+```
+web: cd frontend; npm install; npm run build; npx serve dist -s -l $PORT --single
+api: gunicorn rest_api.wsgi:application --log-file -
+```
+
+
+The Procfile shows two processes:
+web: Handles the frontend by installing dependencies, building the React app, and serving it using npx serve
+api: Handles the Django backend using gunicorn
+
+
+with the command `git push heroku main`
+
+---
+
+need to review the `Procfile` and `settings.py` to ensure that the API and frontend are hosted in the correct places.
+
+
+---
+```python
+"""rest_api URL Configuration
+    IMPORTANT: urls.py should not handle static files.
+"""
+
+from django.contrib import admin
+from django.urls import path
+from rest_api import views
+
+urlpatterns = [
+    path('api/', views.HelloWorld.as_view(), name='hello-world'), # expecting this to be hosted on https://team5-api-eu-5d24fa110c36.herokuapp.com/api/ ISSUE:currently this URL hosts the frontend
+    path('admin/', admin.site.urls),
+]
+```
+
+
+
+
+

--- a/rest_api/urls.py
+++ b/rest_api/urls.py
@@ -12,6 +12,9 @@ Class-based views
 Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
+
+
+    IMPORTANT: urls.py should not handle static files.
 """
 
 from django.contrib import admin
@@ -22,4 +25,3 @@ urlpatterns = [
     path('api/', views.HelloWorld.as_view(), name='hello-world'),
     path('admin/', admin.site.urls),
 ]
-

--- a/usage.md
+++ b/usage.md
@@ -20,8 +20,8 @@ heroku git:remote -a team5-api-eu
 deployment is handled separately for the api and the frontend, although they are in the same repository and sent to the same heroku app in `/api` and `/` respectively.
 
 ```bash
-git push heroku-api main # for the api
-git push heroku main # for the frontend
+# Single deployment command for both frontend and API
+git push heroku main
 ```
 
 heroku logs can be used to view the logs of the deployed application.


### PR DESCRIPTION
please can a team member review docs/1_deployment.md and review the issue with routing the API.



----

Deployment issues: 

Expecting the API to be hosted on `https://team5-api-eu-5d24fa110c36.herokuapp.com/api/`

Expecting the frontend to be hosted on `https://team5-api-eu-5d24fa110c36.herokuapp.com/`


--- 

The Frontend is hosted on `https://team5-frontend-eu-5d24fa110c36.herokuapp.com/`

But the API instead hosts the frontend on `https://team5-api-eu-5d24fa110c36.herokuapp.com/api`


---

deployment is managed by `Procfile` in the root directory

```
web: cd frontend; npm install; npm run build; npx serve dist -s -l $PORT --single
api: gunicorn rest_api.wsgi:application --log-file -
```


The Procfile shows two processes:
web: Handles the frontend by installing dependencies, building the React app, and serving it using npx serve
api: Handles the Django backend using gunicorn


with the command `git push heroku main`

---

need to review the `Procfile` and `settings.py` to ensure that the API and frontend are hosted in the correct places.


---
```python
"""rest_api URL Configuration
    IMPORTANT: urls.py should not handle static files.
"""

from django.contrib import admin
from django.urls import path
from rest_api import views

urlpatterns = [
    path('api/', views.HelloWorld.as_view(), name='hello-world'), # expecting this to be hosted on https://team5-api-eu-5d24fa110c36.herokuapp.com/api/ ISSUE:currently this URL hosts the frontend
    path('admin/', admin.site.urls),
]
```

http://127.0.0.1:8000/api/ works as expected, serves the API.



