### PR TITLE
API working in localhost

### DIFF
--- a/backend/rest_api/urls.py
+++ b/backend/rest_api/urls.py
@@ -20,8 +20,10 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path
 from rest_api import views
+from django.views.generic import RedirectView
 
 urlpatterns = [
-    path('test/', views.HelloWorld.as_view(), name='hello-world'),
+    path('', RedirectView.as_view(url='test/', permanent=False), name='index'),
+    path('test/', views.APITest.as_view(), name='api-test'),
     path('admin/', admin.site.urls),
 ]

--- a/backend/rest_api/views.py
+++ b/backend/rest_api/views.py
@@ -1,7 +1,7 @@
 from rest_framework.views import APIView
 from rest_framework.response import Response
 
-class HelloWorld(APIView):
+class APITest(APIView):
     def get(self, request):
-        data = {"message": "Hello, World!"}
+        data = {"message": "API is working!"}
         return Response(data, content_type="application/json")

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -48,8 +48,9 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'https://team5-api-eu-5d24fa110c36.herokuapp.com',
+        target: 'http://localhost:8000',
         changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, '') // remove /api from the path
       },
     },
   },

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -48,7 +48,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'http://localhost:8000',
+        target: 'http://localhost:8000', // distinct to the backend as opposed to localhost:5173
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, '') // remove /api from the path
       },


### PR DESCRIPTION
 this change won't interfere with deployment.
 
The changes we made are only in the server section of the Vite config, which is only used during local development (npm run dev).

When you build and deploy the frontend (npm run build), Vite doesn't use these proxy settings at all. The production build will still make requests to the actual production URL.



![image](https://github.com/user-attachments/assets/97361245-0f69-4a88-9e88-47e76c954add)


![image](https://github.com/user-attachments/assets/343e0396-0a9b-437b-bebf-e2050a8511e5)

![image](https://github.com/user-attachments/assets/8eaffebd-6858-4fae-a46c-8ebb2538c627)


![image](https://github.com/user-attachments/assets/21a45e29-74da-4465-8b35-f3b44af55503)





